### PR TITLE
add missing s on msisdn

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1704,7 +1704,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "msisdn": {
+                  "msisdns": {
                     "type": "array",
                     "description": "Número do MSISDNS do dispositivo.",
                     "example": "5534991023333"


### PR DESCRIPTION
Essa PR adiciona 'S' no msisdn do endpoint de reset-network. Alteração que não foi aplicada na PR anterior.