### PR TITLE
Corrigindo o format dos campos de data final e inicial na rota de histórico para date

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -12589,7 +12589,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "date-time",
+              "format": "date",
               "example": "2025-12-28"
             }
           },
@@ -12599,7 +12599,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "date-time",
+              "format": "date",
               "example": "2025-12-28"
             }
           }


### PR DESCRIPTION
Acabei notando um erro no formato que coloquei nos campos de data_inicial e data_final na rota "Busca o histórico de uma tag". Estava como **date-time**, mas o correto é **date**, pois o exemplo pede apenas a data, e não o horário.